### PR TITLE
feat: add vercel rewrite for client side routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+	"rewrites": [
+		{
+			"source": "/:path*",
+			"destination": "/index.html"
+		}
+	]
+}


### PR DESCRIPTION
All routes will be redirected to the `index.html` file and routing will be done client-side in the browser. This might be subject to change later.