### PR TITLE
feat: add example for accessible charts

### DIFF
--- a/app/components/card.tsx
+++ b/app/components/card.tsx
@@ -62,19 +62,46 @@ const Card: React.FC<CardProps> = ({ id }) => {
 
 	const { size, color, component: Chart } = charts[id];
 
+	const chartKeys = Object.keys(howXhainContributesData[id][0]);
+
 	return (
-		<div className={`${size}`}>
-			<div className={`p-5 rounded-4xl w-full h-full row-span-1 ${color}`}>
-				<h2 className="text-xl font-bold">{title}</h2>
-				<h3 className="text-xl">{subTitle}</h3>
-				<button
-					onClick={showDialog}
-					className="flex items-center px-3 py-0.5 gap-x-2 bg-xhain-blue-50 text-white rounded-full my-3 hover:bg-xhain-blue-60 focus:outline focus:outline-3 focus:outline-xhain-blue-80 focus:outline-offset-5"
-				>
-					<img src={"/images/i-icon.svg"} alt={""} />
-					{i18n("button.moreInfo")}
-				</button>
-				<div className="w-full h-[300px] overflow-hidden">
+		<figure className={`${size}`}>
+			<div
+				className={`p-5 rounded-2.5xl md:rounded-4xl w-full h-full row-span-1 ${color}`}
+			>
+				<figcaption>
+					<h2 className="text-xl font-bold">{title}</h2>
+					<h3 className="text-xl">{subTitle}</h3>
+					<button
+						onClick={showDialog}
+						className="flex items-center px-3 py-0.5 gap-x-2 bg-xhain-blue-50 text-white rounded-full my-3 hover:bg-xhain-blue-60 focus:outline focus:outline-3 focus:outline-xhain-blue-80 focus:outline-offset-5"
+					>
+						<img src={"/images/i-icon.svg"} alt={""} />
+						{i18n("button.moreInfo")}
+					</button>
+					<table className="sr-only">
+						<caption>{title}</caption>
+						<thead>
+							<tr>
+								{chartKeys.map((key) => (
+									// @ts-expect-error this is correct, but typescript can't infer the types.
+									<th key={key}>{i18n(`chart.${id}.keys.${key}`)}</th>
+								))}
+							</tr>
+						</thead>
+						<tbody>
+							{howXhainContributesData[id].map((entry) => (
+								<tr key={JSON.stringify(entry)}>
+									{Object.keys(entry).map((key) => (
+										// @ts-expect-error this is correct, but typescript can't infer the types.
+										<td key={key}>{entry[key]}</td>
+									))}
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</figcaption>
+				<div className="w-full h-[300px] overflow-hidden" role="img">
 					{Chart && <Chart />}
 					{!Chart && (
 						<>
@@ -98,7 +125,7 @@ const Card: React.FC<CardProps> = ({ id }) => {
 					<p className="text-lg">This is a dialog about {title}</p>
 				</div>
 			</Dialog>
-		</div>
+		</figure>
 	);
 };
 

--- a/app/components/visualizations/line-chart/area.tsx
+++ b/app/components/visualizations/line-chart/area.tsx
@@ -7,6 +7,7 @@ import {
 	xhainBlue50,
 } from "~/components/visualizations/colors";
 import { setYear } from "date-fns";
+import { i18n } from "~/i18n/i18n-utils";
 
 const { eevTotalMwh } = howXhainContributesData;
 type eevPerYear = (typeof eevTotalMwh)[0];
@@ -67,7 +68,7 @@ export const Area: React.FC<AreaProps> = ({ xScale, yScale, sizes }) => {
 				fill="black"
 				fontWeight="700"
 			>
-				Wärme
+				{i18n("chart.eevTotalMwh.legend.heating")}
 			</text>
 
 			<path className="area" d={areaPathElectricity ?? ""} fill={xhainBlue40} />
@@ -77,7 +78,7 @@ export const Area: React.FC<AreaProps> = ({ xScale, yScale, sizes }) => {
 				fill="black"
 				fontWeight="700"
 			>
-				Strom
+				{i18n("chart.eevTotalMwh.legend.electricity")}
 			</text>
 
 			<path className="area" d={areaPathFuels ?? ""} fill={xhainBlue50} />
@@ -87,7 +88,7 @@ export const Area: React.FC<AreaProps> = ({ xScale, yScale, sizes }) => {
 				fill="white"
 				fontWeight="700"
 			>
-				Kraftstoffe
+				{i18n("chart.eevTotalMwh.legend.fuels")}
 			</text>
 		</>
 	);

--- a/app/components/weather-card.tsx
+++ b/app/components/weather-card.tsx
@@ -4,9 +4,9 @@ import { formatDate, formatTemperature } from "~/i18n/i18n-utils";
 import { Skeleton } from "~/components/skeleton/skeleton";
 
 const WeatherCard: React.FC = () => {
-	const { weather } = useCurrentWeather();
+	const { weather, loading } = useCurrentWeather();
 
-	if (!weather) {
+	if (loading || !weather) {
 		return (
 			<div className="max-w-5xl mx-auto w-full h-28 flex flex-row gap-2 items-center justify-between bg-[#F6F8FF]">
 				<Skeleton className="w-14 h-14 rounded-full mt-8 ml-3" />

--- a/app/hooks/use-focus-leave.tsx
+++ b/app/hooks/use-focus-leave.tsx
@@ -1,0 +1,22 @@
+import { type RefObject, useEffect } from "react";
+
+export function useFocusLeave(
+	ref: RefObject<HTMLElement | null>,
+	callback: () => void,
+) {
+	useEffect(() => {
+		if (!ref.current) {
+			return () => {};
+		}
+
+		ref.current.addEventListener("focusout", callback);
+
+		return () => {
+			if (!ref.current) {
+				return;
+			}
+
+			ref.current.removeEventListener("focusout", callback);
+		};
+	}, [ref, callback]);
+}

--- a/app/i18n/translations/de.ts
+++ b/app/i18n/translations/de.ts
@@ -1,39 +1,84 @@
 export const de = {
 	"header.title": "Klima Dashboard Xhain",
 	"charts.title": "Wie trägt XHain zum Klimawandel bei?",
+
 	"chart.thgTotalTons.title": "Treibhausgas-Emissionen",
 	"chart.thgTotalTons.subtitle": "in Tonnen",
+	"chart.thgTotalTons.keys.year": "Jahr",
+	"chart.thgTotalTons.keys.heating_tons": "Summe in Tonnen",
+	"chart.thgTotalTons.keys.electricity_tons": "Summe in Tonnen",
+	"chart.thgTotalTons.keys.fuels_tons": "Summe in Tonnen",
+
 	"chart.thgSector2021Tons.title": "Treibhausgas-Emissionen",
 	"chart.thgSector2021Tons.subtitle": "nach Verbrauchssektoren",
+	"chart.thgSector2021Tons.keys.sector": "Sektor",
+	"chart.thgSector2021Tons.keys.total_tons": "Summe in Tonnen",
+	"chart.thgSector2021Tons.keys.percentage": "Prozent",
+
 	"chart.consumptionEmissionsTons.title":
 		"Konsum- und Ernährungsbedingte Emissionen",
 	"chart.consumptionEmissionsTons.subtitle": "in 2024",
+	"chart.consumptionEmissionsTons.keys.xhain":
+		"Friedrichshain-Kreuzberg (X-Hain)",
+	"chart.consumptionEmissionsTons.keys. per_person": "Pro Person",
+
 	"chart.eevTotalMwh.title": "Endenergieverbrauch",
 	"chart.eevTotalMwh.subtitle": "in MWh",
+	"chart.eevTotalMwh.legend.heating": "Wärme",
+	"chart.eevTotalMwh.legend.electricity": "Strom",
+	"chart.eevTotalMwh.legend.fuels": "Kraftstoffe",
+	"chart.eevTotalMwh.keys.year": "Jahr",
+	"chart.eevTotalMwh.keys.heating_mwh": "Heizung in Megawattstunden",
+	"chart.eevTotalMwh.keys.electricity_mwh": "Strom in Megawattstunden",
+	"chart.eevTotalMwh.keys.fuels_mwh": "Kraftstoffe in Megawattstunden",
+
 	"chart.eevSector2021Mwh.title": "Endenergieverbrauch",
 	"chart.eevSector2021Mwh.subtitle": "nach Verbrauchssektoren",
+	"chart.eevSector2021Mwh.keys.sector": "Sektor",
+	"chart.eevSector2021Mwh.keys.total_mwh": "Summe in Megawattstunden",
+	"chart.eevSector2021Mwh.keys.percentage": "Prozent",
+
 	"chart.heatingMix2021Summarized.title": "Wärmemix der Haushalte",
 	"chart.heatingMix2021Summarized.subtitle":
-		" Anteile der einzelnen Verkehrsmittel an der gesamten ⁠Verkehrsleistung ",
+		" Anteile der einzelnen Verkehrsmittel an der gesamten Verkehrsleistung",
+	"chart.heatingMix2021Summarized.keys.source": "Quelle",
+	"chart.heatingMix2021Summarized.keys.total_mwh": "Summe in Megawattstunden",
+
 	"chart.modalSplit2018.title": "Modal Split",
 	"chart.modalSplit2018.subtitle": "Modal Split",
+	"chart.modalSplit2018.keys.area": "Fläche",
+	"chart.modalSplit2018.keys.miv": "Motorisierter Personenverkehr",
+	"chart.modalSplit2018.keys.oepnv": "Öffentlicher Personen-Nahverkehr",
+	"chart.modalSplit2018.keys.foot": "Fußgänger:innen",
+	"chart.modalSplit2018.keys.bike": "Fahradfahrende",
+
 	"chart.traffic2022Summarized.title": "Verkehr",
 	"chart.traffic2022Summarized.subtitle": "nach Bereich in %",
+	"chart.traffic2022Summarized.keys.sector": "Sektor",
+	"chart.traffic2022Summarized.keys.percentage_thg": "Prozent Treibhausgas",
+
 	"chart.reductionPathScenario175Thg.title": "Reduktionspfad",
 	"chart.reductionPathScenario175Thg.subtitle":
 		"Klimaschutzszenario (1,75 Grad, 67 % Wahrscheinlichkeit)",
+
 	"chart.hotDays.title": "Heiße Tage",
 	"chart.hotDays.subtitle": "",
+
 	"chart.mediumTemperature.title": "Mittlere Jahrestemperatur",
 	"chart.mediumTemperature.subtitle": "in Friedrichshain-Kreuzberg nach Phasen",
+
 	"chart.precipitationMm.title": "Niederschläge",
 	"chart.precipitationMm.subtitle": "in Milliliter",
+
 	"button.moreInfo": "mehr Infos",
 
 	"howToReachGoals.title":
 		"Wie kann XHain die Klimaschutzziele zukünftig erreichen?",
+
 	"consequences.title": "Wie wirkt sich der Klimawandel auf XHain aus?",
+
 	"currentProjects.title": "Was passiert bereits in Xhain?",
+
 	"footer.cardHeading":
 		"Hast du Fragen zum Klimadashboard und den Klimakonzepten?",
 	"footer.cardSubHeading": "Schreib uns!",

--- a/app/i18n/translations/en.ts
+++ b/app/i18n/translations/en.ts
@@ -3,39 +3,86 @@ import { de } from "./de";
 export const en: typeof de = {
 	"header.title": "Climate Dashboard Xhain",
 	"charts.title": "How does XHain contribute to climate change?",
+
 	"chart.thgTotalTons.title": "Greenhouse gas emissions",
 	"chart.thgTotalTons.subtitle": "in tons of CO2 equivalent",
+	"chart.thgTotalTons.keys.year": "Year",
+	"chart.thgTotalTons.keys.heating_tons": "Sum in Tons",
+	"chart.thgTotalTons.keys.electricity_tons": "Sum in Tons",
+	"chart.thgTotalTons.keys.fuels_tons": "Sum in Tons",
+
 	"chart.thgSector2021Tons.title": "Greenhouse gas emissions",
 	"chart.thgSector2021Tons.subtitle": "by consumption sectors",
+	"chart.thgSector2021Tons.keys.sector": "Sector",
+	"chart.thgSector2021Tons.keys.total_tons": "Sum in Tons",
+	"chart.thgSector2021Tons.keys.percentage": "Percentage",
+
 	"chart.consumptionEmissionsTons.title":
 		"Consumption and nutrition-related emissions",
 	"chart.consumptionEmissionsTons.subtitle": "in 2024",
+	"chart.consumptionEmissionsTons.keys.xhain":
+		"Friedrichshain-Kreuzberg (X-Hain)",
+	"chart.consumptionEmissionsTons.keys. per_person": "Per person",
+
 	"chart.eevTotalMwh.title": "Final energy consumption",
 	"chart.eevTotalMwh.subtitle": "in MWh",
+	"chart.eevTotalMwh.legend.heating": "Heating",
+	"chart.eevTotalMwh.legend.electricity": "Electricity",
+	"chart.eevTotalMwh.legend.fuels": "Fuels",
+	"chart.eevTotalMwh.keys.year": "Year",
+	"chart.eevTotalMwh.keys.heating_mwh": "Heating in Megawatt Hours",
+	"chart.eevTotalMwh.keys.electricity_mwh": "Electricity in Megawatt Hours",
+	"chart.eevTotalMwh.keys.fuels_mwh": "Fuels in Megawatt Hours",
+
 	"chart.eevSector2021Mwh.title": "Final energy consumption",
 	"chart.eevSector2021Mwh.subtitle": "by consumption sectors",
+	"chart.eevSector2021Mwh.keys.sector": "Sector",
+	"chart.eevSector2021Mwh.keys.total_mwh": "Sum in Megawatt Hours",
+	"chart.eevSector2021Mwh.keys.percentage": "Percentage",
+
 	"chart.heatingMix2021Summarized.title": "Heating mix of households",
-	"chart.heatingMix2021Summarized.subtitle": "",
+	"chart.heatingMix2021Summarized.subtitle":
+		"Shares of the individual means of transport in total transport performance",
+	"chart.heatingMix2021Summarized.keys.source": "Source",
+	"chart.heatingMix2021Summarized.keys.total_mwh": "Sum in Megawatt hours",
+
 	"chart.modalSplit2018.title": "Modal Split",
 	"chart.modalSplit2018.subtitle":
 		"Shares of the individual means of transport in total transport performance",
+	"chart.modalSplit2018.keys.area": "Area",
+	"chart.modalSplit2018.keys.miv": "Motorized individual transport",
+	"chart.modalSplit2018.keys.oepnv": "Public transport",
+	"chart.modalSplit2018.keys.foot": "Pedestrians",
+	"chart.modalSplit2018.keys.bike": "Cyclists",
+
 	"chart.traffic2022Summarized.title": "Traffic",
 	"chart.traffic2022Summarized.subtitle": "by area in %",
+	"chart.traffic2022Summarized.keys.sector": "Sector",
+	"chart.traffic2022Summarized.keys.percentage_thg":
+		"Greenhouse gas percentage",
+
 	"chart.reductionPathScenario175Thg.title": "Reduction path",
 	"chart.reductionPathScenario175Thg.subtitle":
 		"Climate protection scenario (1.75 degrees, 67% probability)",
+
 	"chart.hotDays.title": "Hot days",
 	"chart.hotDays.subtitle": "",
+
 	"chart.mediumTemperature.title": "Average annual temperature",
 	"chart.mediumTemperature.subtitle": "in Friedrichshain-Kreuzberg by phases",
+
 	"chart.precipitationMm.title": "Precipitation",
 	"chart.precipitationMm.subtitle": "in milliliters",
+
 	"button.moreInfo": "more info",
 
 	"howToReachGoals.title":
 		"How can XHain achieve its climate protection goals in the future?",
+
 	"consequences.title": "How does climate change affect XHain?",
+
 	"currentProjects.title": "What is already happening in XHain?",
+
 	"footer.cardHeading":
 		"Do you have any questions about the climate dashboard and the climate concepts?",
 	"footer.cardSubHeading": "write to us!",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,7 @@ export default {
 			},
 			borderRadius: {
 				"4xl": "30px",
+				"2.5xl": "20px",
 				"5px": "5px",
 				xs: "1px",
 			},


### PR DESCRIPTION
This PR adds figure/figcaption to the charts to make the charts available for screen readers, and also enables focusable years in the `Endenergieverbrauch` chart via pressing the `Tab` key. 